### PR TITLE
 Alleviate memory problems for long generations 

### DIFF
--- a/gplearn/genetic.py
+++ b/gplearn/genetic.py
@@ -1036,6 +1036,9 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
                 parents = None
             else:
                 parents = self._programs[gen - 1]
+            
+            if gen > 1:
+                self._programs[gen-2] =[]
 
             # Parallel loop
             n_jobs, n_programs, starts = _partition_estimators(

--- a/gplearn/genetic.py
+++ b/gplearn/genetic.py
@@ -925,7 +925,7 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
                    oob_fitness,
                    remaining_time))
 
-    def fit(self, X, y, sample_weight=None):
+    def fit(self, X, y, sample_weight=None, keep_past_generations=True):
         """Fit the Genetic Program according to X, y.
 
         Parameters
@@ -1037,7 +1037,7 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
             else:
                 parents = self._programs[gen - 1]
             
-            if gen > 1:
+            if keep_past_generations != True:
                 self._programs[gen-2] =[]
 
             # Parallel loop


### PR DESCRIPTION
Erases past generations, doesn't seem to cause other errors, still gives great results.

Before adding this, memory usage would start from a couple of GB, and balloon to >30 GB over the course of a few hours, hundreds of generations, thousands of population size.

After adding this, memory usage stays constant after the first two generations, allowing an arbitrarily large number of generations to be ran.