### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ virtualenv:
   system_site_packages: true
 env:
   matrix:
-    - PYTHON_VERSION="2.6" LATEST="true"
     - PYTHON_VERSION="2.7" COVERAGE="true" LATEST="true"
     - PYTHON_VERSION="2.7" SKLEARN_VERSION="0.15.2"
     - PYTHON_VERSION="3.4" LATEST="true"

--- a/gplearn/skutils/fixes.py
+++ b/gplearn/skutils/fixes.py
@@ -12,8 +12,6 @@ at which the fixe is no longer needed.
 
 import inspect
 import warnings
-import sys
-import functools
 
 import numpy as np
 import scipy.sparse as sp
@@ -189,30 +187,6 @@ except ImportError:
 
 
 try:
-    from itertools import combinations_with_replacement
-except ImportError:
-    # Backport of itertools.combinations_with_replacement for Python 2.6,
-    # from Python 3.4 documentation (http://tinyurl.com/comb-w-r), copyright
-    # Python Software Foundation (https://docs.python.org/3/license.html)
-    def combinations_with_replacement(iterable, r):
-        # combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC
-        pool = tuple(iterable)
-        n = len(pool)
-        if not n and r:
-            return
-        indices = [0] * r
-        yield tuple(pool[i] for i in indices)
-        while True:
-            for i in reversed(range(r)):
-                if indices[i] != n - 1:
-                    break
-            else:
-                return
-            indices[i:] = [indices[i] + 1] * (r - i)
-            yield tuple(pool[i] for i in indices)
-
-
-try:
     from numpy import isclose
 except ImportError:
     def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
@@ -309,25 +283,6 @@ if np_version < (1, 8):
             return flag[indx][rev_idx]
 else:
     from numpy import in1d
-
-
-if sys.version_info < (2, 7, 0):
-    # partial cannot be pickled in Python 2.6
-    # http://bugs.python.org/issue1398
-    class partial(object):
-        def __init__(self, func, *args, **keywords):
-            functools.update_wrapper(self, func)
-            self.func = func
-            self.args = args
-            self.keywords = keywords
-
-        def __call__(self, *args, **keywords):
-            args = self.args + args
-            kwargs = self.keywords.copy()
-            kwargs.update(keywords)
-            return self.func(*args, **kwargs)
-else:
-    from functools import partial
 
 
 if np_version < (1, 6, 2):

--- a/gplearn/skutils/testing.py
+++ b/gplearn/skutils/testing.py
@@ -13,7 +13,6 @@ import inspect
 import pkgutil
 import warnings
 import sys
-import re
 import platform
 
 import scipy as sp
@@ -70,31 +69,14 @@ except ImportError:
         assert_false(x in container, msg="%r in %r" % (x, container))
 
 try:
-    from nose.tools import assert_raises_regex
+    # Python 3.4+
+    # assert_raises_regexp is deprecated in Python 3.4 in favor of
+    # assert_raises_regex but let's keep the backward compat in scikit-learn
+    # with the old name for now
+    from nose.tools import assert_raises_regex as assert_raises_regexp
 except ImportError:
-    # for Py 2.6
-    def assert_raises_regex(expected_exception, expected_regexp,
-                            callable_obj=None, *args, **kwargs):
-        """Helper function to check for message patterns in exceptions"""
-
-        not_raised = False
-        try:
-            callable_obj(*args, **kwargs)
-            not_raised = True
-        except Exception as e:
-            error_message = str(e)
-            if not re.compile(expected_regexp).search(error_message):
-                raise AssertionError("Error message should match pattern "
-                                     "%r. %r does not." %
-                                     (expected_regexp, error_message))
-        if not_raised:
-            raise AssertionError("Should have raised %r" %
-                                 expected_exception(expected_regexp))
-
-# assert_raises_regexp is deprecated in Python 3.4 in favor of
-# assert_raises_regex but lets keep the bacward compat in scikit-learn with
-# the old name for now
-assert_raises_regexp = assert_raises_regex
+    # Python 2.7
+    from nose.tools import assert_raises_regexp
 
 
 def _assert_less(a, b, msg=None):

--- a/gplearn/tests/test_genetic.py
+++ b/gplearn/tests/test_genetic.py
@@ -14,8 +14,8 @@ from gplearn.genetic import SymbolicRegressor, SymbolicTransformer
 from gplearn.fitness import weighted_pearson, weighted_spearman
 from gplearn._program import _Program
 from gplearn.fitness import _fitness_map
-from gplearn.functions import (add2, sub2, mul2, div2, sqrt1, log1, abs1, neg1,
-                               inv1, max2, min2, sin1, cos1, tan1)
+from gplearn.functions import (add2, sub2, mul2, div2, sqrt1, log1, abs1, max2,
+                               min2)
 from gplearn.functions import _Function
 from gplearn.fitness import make_fitness
 from scipy.stats import pearsonr, spearmanr

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 """Genetic Programming in Python, with a scikit-learn inspired API"""
 
 import sys
-from sklearn.externals import joblib
 from setuptools import setup, find_packages
 import gplearn
 
@@ -27,7 +26,6 @@ setup_options = dict(
                  'Operating System :: MacOS',
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 2',
-                 'Programming Language :: Python :: 2.6',
                  'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3',
                  'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
Fixes #29.

The pip installs for gplearn from PyPI for the last year shows no demand:
```
$ pypinfo -d 365 --percent --pip gplearn pyversion
python_version percent download_count
-------------- ------- --------------
2.7              43.0%            776
3.6              26.9%            485
3.5              26.1%            471
3.4               3.9%             71

```