### PR TITLE
adds a slim parameter which drastically reduces the memory footprint

### DIFF
--- a/gplearn/genetic.py
+++ b/gplearn/genetic.py
@@ -404,6 +404,7 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
 
         prior_generations = self.get_prior_generation_count()
         n_more_generations = self.generations - prior_generations
+        population = None
 
         if n_more_generations < 0:
             raise ValueError('generations=%d must be larger or equal to '
@@ -493,6 +494,9 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
                 best_fitness = fitness[np.argmin(fitness)]
                 if best_fitness <= self.stopping_criteria:
                     break
+
+        if population is None:
+            population = self.get_prior_generation()
 
         if isinstance(self, RegressorMixin):
             # Find the best individual in the final generation

--- a/gplearn/tests/test_genetic.py
+++ b/gplearn/tests/test_genetic.py
@@ -1026,6 +1026,27 @@ def test_slim_parameter():
     assert_equal(est._best_programs[0].parents, None)
 
 
+def test_low_memory_warm_start():
+    """Check the warm_start functionality works as expected."""
+
+    est = SymbolicRegressor(generations=20,
+                            random_state=415,
+                            slim=True)
+    est.fit(boston.data, boston.target)
+    cold_fitness = est._program.fitness_
+    cold_program = est._program.__str__()
+
+    # Check warm starts get the same result
+    est = SymbolicRegressor(generations=10, random_state=415)
+    est.fit(boston.data, boston.target)
+    est.set_params(generations=20, warm_start=True)
+    est.fit(boston.data, boston.target)
+    warm_fitness = est._program.fitness_
+    warm_program = est._program.__str__()
+    assert_almost_equal(cold_fitness, warm_fitness)
+    assert_equal(cold_program, warm_program)
+
+
 
 if __name__ == "__main__":
     import nose

--- a/gplearn/tests/test_genetic.py
+++ b/gplearn/tests/test_genetic.py
@@ -1005,6 +1005,28 @@ def test_warm_start():
     assert_equal(cold_program, warm_program)
 
 
+def test_slim_parameter():
+    est = SymbolicRegressor(population_size=50,
+                            generations=5,
+                            tournament_size=5,
+                            random_state=0,
+                            slim=True)
+    est.fit(boston.data, boston.target)
+    assert_equal(len(est._programs), 0)
+    assert_equal(est._program.parents, None)
+
+    est = SymbolicTransformer(population_size=50,
+                              generations=5,
+                              tournament_size=5,
+                              hall_of_fame=20,
+                              random_state=0,
+                              slim=True)
+    est.fit(boston.data, boston.target)
+    assert_equal(len(est._programs), 0)
+    assert_equal(est._best_programs[0].parents, None)
+
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()


### PR DESCRIPTION
The slim parameter indicates to the SymbolicRegressor and SymbolicTransformer that no historical information about parents of any individual needs to be retained, reducing the number of objects kept in memory during and after training, drastically. This should lead to a near constant memory footprint allowing for more generations to be trained within the same memory limit.

This parameter can be set to `True` when the purpose of the training run is to achieve a high result through many generations. It is no longer possible to analyze the parent graph of the resulting program, so it should be set to `False` (default) if that analysis is relevant for your purposes.