### PR TITLE
get best program of whole evolution and add low_memory parameter

### DIFF
--- a/gplearn/genetic.py
+++ b/gplearn/genetic.py
@@ -448,7 +448,7 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
                         if idx not in indices:
                             self._programs[old_gen - 1][idx] = None
             elif gen > 0:
-                # only remove programs in generation before and set generation before the parents to None
+                # remove old programs and delete everyone in the gen before the parent's gen
                 indices = []
                 for program in self._programs[gen]:
                     if program is not None:
@@ -458,9 +458,9 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
                 indices = set(indices)
                 for idx in range(self.population_size):
                     if idx not in indices:
-                        self._programs[gen - 1][idx] = None
+                        self._programs[-2][idx] = None
                     if gen > 1:
-                        self._programs[gen - 2][idx] = None
+                        self._programs[-3][idx] = None
 
 
             # Record run details

--- a/gplearn/genetic.py
+++ b/gplearn/genetic.py
@@ -392,6 +392,9 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
             # Print header fields
             self._verbose_reporter()
 
+        if isinstance(self, RegressorMixin):
+            self._program = None
+
         for gen in range(prior_generations, self.generations):
 
             start_time = time()
@@ -475,12 +478,17 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
                 if best_fitness <= self.stopping_criteria:
                     break
 
-        if isinstance(self, RegressorMixin):
-            # Find the best individual in the final generation
-            if self._metric.greater_is_better:
-                self._program = self._programs[-1][np.argmax(fitness)]
-            else:
-                self._program = self._programs[-1][np.argmin(fitness)]
+            if isinstance(self, RegressorMixin):
+                # Find the best individual from all generations
+                if self._program is None:
+                    self._program = best_program
+                elif self._metric.greater_is_better:
+                    if(best_program.raw_fitness_ >= self._program.raw_fitness_):
+                        self._program = best_program
+                else:
+                    if(best_program.raw_fitness_ <= self._program.raw_fitness_):
+                        self._program = best_program
+
 
         if isinstance(self, TransformerMixin):
             # Find the best individuals in the final generation

--- a/gplearn/genetic.py
+++ b/gplearn/genetic.py
@@ -161,6 +161,7 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
                  population_size=1000,
                  hall_of_fame=None,
                  n_components=None,
+                 _program = None,
                  generations=20,
                  tournament_size=20,
                  stopping_criteria=0.0,
@@ -184,6 +185,7 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.population_size = population_size
         self.hall_of_fame = hall_of_fame
         self.n_components = n_components
+        self._program = _program
         self.generations = generations
         self.tournament_size = tournament_size
         self.stopping_criteria = stopping_criteria
@@ -391,9 +393,6 @@ class BaseSymbolic(six.with_metaclass(ABCMeta, BaseEstimator)):
         if self.verbose:
             # Print header fields
             self._verbose_reporter()
-
-        if isinstance(self, RegressorMixin):
-            self._program = None
 
         for gen in range(prior_generations, self.generations):
 

--- a/gplearn/tests/test_genetic.py
+++ b/gplearn/tests/test_genetic.py
@@ -1053,6 +1053,52 @@ def test_warm_start():
     assert_equal(cold_program, warm_program)
 
 
+def test_low_memory():
+    est = SymbolicRegressor(generations=10,
+                            random_state=56,
+                            low_memory=True)
+    est.fit(boston.data, boston.target)
+    
+    idx = est._program.parents['donor_idx']
+    assert_false(est._programs[-2][idx] is None)
+    idx_parent = est._programs[-2][idx].parents['donor_idx']
+    assert_true(est._programs[-3][idx_parent] is None)
+
+
+    est = SymbolicTransformer(generations=10,
+                              hall_of_fame=20,
+                              random_state=56,
+                              low_memory=True)
+    est.fit(boston.data, boston.target)
+
+    idx = est._best_programs[0].parents['donor_idx']
+    assert_false(est._programs[-2][idx] is None)
+    idx_parent = est._programs[-2][idx].parents['donor_idx']
+    assert_true(est._programs[-3][idx_parent] is None)
+
+
+def test_low_memory_warm_start():
+    """Check the warm_start functionality works as expected together with low_memory."""
+
+    est = SymbolicRegressor(generations=20,
+                            random_state=415,
+                            low_memory=True)
+    est.fit(boston.data, boston.target)
+    cold_fitness = est._program.fitness_
+    cold_program = est._program.__str__()
+
+    # Check warm start with low memory gets the same result
+    est = SymbolicRegressor(generations=10,
+                            random_state=415, 
+                            low_memory=True)
+    est.fit(boston.data, boston.target)
+    est.set_params(generations=20, warm_start=True)
+    est.fit(boston.data, boston.target)
+    warm_fitness = est._program.fitness_
+    warm_program = est._program.__str__()
+    assert_almost_equal(cold_fitness, warm_fitness)
+    assert_equal(cold_program, warm_program)
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()


### PR DESCRIPTION
Changes how _program is determined during a program run so that it returns the best program found during the whole evolution process. Before it returned only the best program found in the last generation.

I also did my own take on the low_memory parameter proposed in issue #89 and pull request #92.
Pull request #92 doesn't pass all tests, the creater of the pull request doesn't seem to answer (last message 11 days ago) and my implementation is more simple. Nevertheless kudos to @bartolkaruza for the idea and trying to fix it.
I also added tests for the new parameter.

**RAM when low_memory = False:**
![ram_lowmem-false](https://user-images.githubusercontent.com/9419801/48290649-e8a06d80-e473-11e8-896b-7068bc737432.png)

**RAM when low_memory = True:**
![ram_lowmem-true](https://user-images.githubusercontent.com/9419801/48290659-f6ee8980-e473-11e8-8fac-80da964511d7.png)


**Pickle size:**
![pickle size](https://user-images.githubusercontent.com/9419801/48290683-07066900-e474-11e8-8487-af0a49d43377.png)


fixes #89
fixes #107 