### PR TITLE
mutate one random node if no node was selected

### DIFF
--- a/gplearn/_program.py
+++ b/gplearn/_program.py
@@ -632,6 +632,9 @@ class _Program(object):
                                     self.p_point_replace)
                            else False
                            for _ in range(len(program))])[0]
+        
+        if len(mutate) == 0 and self.p_point_replace > 0:
+            mutate = [np.random.randint(len(program))]
 
         for node in mutate:
             if isinstance(program[node], _Function):


### PR DESCRIPTION
fixes #124 

It fixes that small programs are rarely mutated at all because of their length and the small probability assigned to p_point_replace.
This solution still reproduces by a small chance if the randomly selected replacement is the same as the one it replaces (functions and variables).
