### PR TITLE
mutate one random node if no node was selected

### DIFF
--- a/gplearn/_program.py
+++ b/gplearn/_program.py
@@ -633,6 +633,9 @@ class _Program(object):
                            else False
                            for _ in range(len(program))])[0]
 
+        if len(mutate) == 0 and self.p_point_replace > 0:
+            mutate = [random_state.randint(len(program))]
+
         for node in mutate:
             if isinstance(program[node], _Function):
                 arity = program[node].arity

--- a/gplearn/tests/test_genetic.py
+++ b/gplearn/tests/test_genetic.py
@@ -431,7 +431,7 @@ def test_genetic_operations():
     assert_equal(gp.program, test_gp)
     assert_equal([f.name if isinstance(f, _Function) else f
                   for f in gp.point_mutation(random_state)[0]],
-                 ['mul', 'div', 8, 1, 'sub', 9, 0.5])
+                 ['mul', 'div', 1, 1, 'sub', 9, 0.5])
     assert_equal(gp.program, test_gp)
 
 


### PR DESCRIPTION
fixes #124

It fixes that small programs are rarely mutated at all because of their length and the small probability assigned to p_point_replace.
This solution still reproduces by a small chance if the randomly selected replacement is the same as the one it replaces (functions and variables).

In test_genetic one test had to be adapted because the point_mutation now mutated a node instead of doing nothing.