### PR TITLE
documentation fixes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,8 +7,12 @@ Release History
 Version 0.4.0
 -------------
 
-- Following scikit-learn's lead, gplearn will no longer support Python 2.7 or
-  Python 3.4.
+- Drop support for Python 2.7 and Python 3.4 to ensure compatibility with
+  ``scikit-learn``.
+- Allow users to express feature names as strings rather than X0, X1, etc.
+  Graphviz and ``print()`` output can now be customized by setting
+  ``feature_names=[...]`` in :class:`genetic.SymbolicRegressor` or
+  :class:`genetic.SymbolicTransformer`.
 - Allow users to exclude constants from their programs by setting
   ``const_range=None`` in :class:`genetic.SymbolicRegressor` or
   :class:`genetic.SymbolicTransformer`.

--- a/gplearn/_program.py
+++ b/gplearn/_program.py
@@ -498,6 +498,8 @@ class _Program(object):
         """
         if program is None:
             program = self.program
+        # Choice of crossover points follows Koza's (1992) widely used approach
+        # of choosing functions 90% of the time and leaves 10% of the time.
         probs = np.array([0.9 if isinstance(node, _Function) else 0.1
                           for node in program])
         probs = np.cumsum(probs / probs.sum())


### PR DESCRIPTION
fixes #126 
fixes #148 

Missed feature names in the changelog.
Explanation of the crossover point choice from source docs.