### PR TITLE
docs: fix simple typo, intializing -> initializing

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -298,7 +298,7 @@ Perhaps temporal variables have a seasonal effect?)
 
 If you think that the problem requires a very large formula to solve,
 start with a larger program depth. And if your dataset has many variables, 
-perhaps the “full” initialization method (intializing the population with
+perhaps the “full” initialization method (initializing the population with
 full-size programs) makes more sense than waiting for programs to grow
 large enough to make use of all variables.
 


### PR DESCRIPTION
There is a small typo in doc/intro.rst.

Closes #231

<!-- Thanks for contributing to gplearn!
Please ensure you have taken a look at the contribution guidelines:
https://gplearn.readthedocs.io/en/stable/contributing.html -->

**Reference Issues/PRs**
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

**What does this implement/fix? Explain your changes.**
