### PR TITLE
Add missing `sig1` to `_function_map` and correct comments in protected operators.

### DIFF
--- a/gplearn/functions.py
+++ b/gplearn/functions.py
@@ -179,5 +179,4 @@ _function_map = {'add': add2,
                  'min': min2,
                  'sin': sin1,
                  'cos': cos1,
-                 'tan': tan1,
-                 'sig': sig1}
+                 'tan': tan1}


### PR DESCRIPTION
`sig` is missing from `_function_map`

See line https://github.com/trevorstephens/gplearn/blob/087f9572d06d102cbc7a77fcfe0cac9da9b8aaef/gplearn/functions.py#L167