### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -295,4 +295,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}


### PR DESCRIPTION
**What does this implement/fix? Explain your changes.**

The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.